### PR TITLE
Bug/remove pypi publish

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ If you fix a bug, open a GitHub pull request against the `dev` branch with the f
 
 ### Adding or Fixing Documentation
 
-If you want to improve the current documentation, that includes adding new documentation, fixing grammar, spelling, and format errors open a GitHub pull request against the `gh-pages` branch with your changes.
+If any updates need to be made to the pyRACF documentation, open a GitHub pull request against the `gh-pages-dev` branch with your changes. This may include updates to document new functionality or updates to correct errors or mistakes in the existing documentation.
 
 ## Style Guidelines
 
@@ -102,7 +102,7 @@ When contributing to pyRACF, think about the following:
 
 * Make any necessary updates to `pyproject.toml`.
 * Make any necessary updates to `README.md`.
-* Make any necessary updates to the gitHub pages documentation in the `gh-pages` branch.
+* Make any necessary updates to the gitHub pages documentation in the `gh-pages` branch _(Pull requests should be opened against the `gh-pages-dev` branch)_.
 * Add any available test cases to `/tests`.
 * Verify `__init__.py` files are updated properly.
 * Ensure that you have __pre-commit Hooks__ setup to ensure that **isort**, **black**, **flake8**, and **pylint** are run against the code for every commit you make.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -212,14 +212,6 @@ def publish(
             string(
                 credentialsId: 'pyracf-github-access-token',
                 variable: 'github_access_token'
-            ),
-            string(
-                credentialsId: 'pyracf-pypi-username',
-                variable: 'pypi_username'
-            ),
-            string(
-                credentialsId: 'pyracf-pypi-password',
-                variable: 'pypi_password'
             )
         ]
     ) {
@@ -281,17 +273,6 @@ def publish(
                 + '-H "Content-Type: application/octet-stream" '
                 + "\"https://uploads.github.com/repos/ambitus/pyracf/releases/${release_id}/assets?name=${wheel_publish}\" "
                 + "--data-binary \"@${wheel_default}\""
-            )
-
-            echo "Uploading '${wheel_default}' as '${wheel_publish}' to pypi repository..."
-
-            sh(
-                ". venv_${python}/bin/activate && "
-                + "mv ${wheel_default} ${wheel_publish} && "
-                + "${python} -m twine upload --repository test ${wheel_publish} " 
-                + '--non-interactive '
-                + '-u ${pypi_username} '
-                + '-p ${pypi_password}'
             )
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,9 +146,9 @@ def create_python_executables_and_wheels_map(python_versions) {
     for (version in python_versions) {
         python_executables_and_wheels_map["python3.${version}"] = [
             "defaultName": (
-                "pyRACF-${pyracf_version}-cp3${version}-cp3${version}-${os}_${zos_release}_${processor}.whl"
+                "pyracf-${pyracf_version}-cp3${version}-cp3${version}-${os}_${zos_release}_${processor}.whl"
             ),
-            "publishName": "pyRACF-${pyracf_version}-cp3${version}-none-any.whl"
+            "publishName": "pyracf-${pyracf_version}-cp3${version}-none-any.whl"
         ]
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -283,11 +283,12 @@ def build_description(python_executables_and_wheels_map, release, milestone) {
 
     for (python in python_executables_and_wheels_map.keySet()) {
         def wheel = python_executables_and_wheels_map[python]["publishName"]
-        python = python.replace("python", "Python ")
+        def python_executable = python
+        def python_label = python.replace("python", "Python ")
         description += (
-            "Install for ${python}:\\n"
+            "Install for ${python_label}:\\n"
             + "```\\ncurl -O -L https://github.com/ambitus/pyracf/releases/download/${release}/${wheel} "
-            + "&& python3 -m pip install ${wheel}\\n```\\n"
+            + "&& ${python_executable} -m pip install ${wheel}\\n```\\n"
         )
     }
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ As automation becomes more and more prevalent, the need to manage the security e
 
 ### Installation
 
-```shell
-python3 -m pip install pyracf
-```
+:warning: _pyRACF will eventually be made available on [pypi.org](https://pypi.org/), but currently python wheel distributions for pyRACF are only available for manual download and installation via GitHub._
+
+* [Download & Install From GitHub](https://github.com/ambitus/pyracf/releases)
 
 ### Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
     requires = ["setuptools>=61"]
 
 [project]
-    name="pyRACF"
+    name="pyracf"
     version="1.0a2"
     description="Python interface to RACF using IRRSMO00 RACF Callable Service."
     authors = [
@@ -17,8 +17,8 @@
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
-        "License :: IBM Internal For Now...",
-        "Operating System :: z/OS",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: POSIX :: Other",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -5,4 +5,3 @@ flake8>=6.1.0
 pylint>=2.17.5
 coverage>=7.3.1
 wheel>=0.41.2
-twine>=4.0.2


### PR DESCRIPTION
### :bulb: Issue Reference

N/A

### :computer: What does this address?

Given that one of twine's dependencies now has a dependency on Rust, I have decided to remove the pypi repository publish stage from the Jenkinsfile for now. 

I investigated some alternatives, namely poetry and flit. Both of these would require some significant changes to our current build process and package metadata. If we are unable to find a way to get twine working, maybe it could be worth investigating these further when we are ready to start publishing to pypi since they both seem to work on z/OS with no issues.

### :pager: Implementation Details

* Remove section from Jenkinsfile that does pypi repository upload using twine.
* Remove twine from development dependencies
* Update README to point to GitHub releases for downloading and installing pyRACF.
* Updates to package metadata.
  * Make package name lowercase.
  * Update classifiers.

### :clipboard: Is there a test case?

Again, the Jenkins server being used is internal, however, after removing the pypi repository upload stage with twine, everything else still works with no issue.