### PR TITLE
Error and Error Handling Changes

### DIFF
--- a/pyracf/__init__.py
+++ b/pyracf/__init__.py
@@ -2,6 +2,7 @@
 from .access.access_admin import AccessAdmin
 from .common.add_operation_error import AddOperationError
 from .common.alter_operation_error import AlterOperationError
+from .common.null_response_error import NullResponseError
 from .common.security_request_error import SecurityRequestError
 from .common.segment_error import SegmentError
 from .common.segment_trait_error import SegmentTraitError
@@ -9,5 +10,6 @@ from .connection.connection_admin import ConnectionAdmin
 from .data_set.data_set_admin import DataSetAdmin
 from .group.group_admin import GroupAdmin
 from .resource.resource_admin import ResourceAdmin
+from .scripts.install_precheck import define_precheck_profile
 from .setropts.setropts_admin import SetroptsAdmin
 from .user.user_admin import UserAdmin

--- a/pyracf/common/null_response_error.py
+++ b/pyracf/common/null_response_error.py
@@ -1,0 +1,20 @@
+"""Exception to use when no data is returned by IRRSMO00."""
+
+
+class NullResponseError(Exception):
+    """
+    Raised when the no xml string is returned by IRRSMO00.
+    """
+
+    def __init__(self, xml_str: str) -> None:
+        self.message = "Security request made to IRRSMO00 failed."
+        self.xml_data = xml_str
+        self.message += (
+            "\n\nCheck to see if proper RACF permissions are in place.\n"
+            + "For `set` or `alter` functions, you must have at least READ "
+            + "access to `IRR.IRRSMO00.PRECHECK` in the `XFACILIT` class."
+        )
+        self.message = f"({self.__class__.__name__}) {self.message}"
+
+    def __str__(self) -> str:
+        return self.message

--- a/pyracf/common/security_admin.py
+++ b/pyracf/common/security_admin.py
@@ -7,6 +7,7 @@ from typing import Any, List, Tuple, Union
 
 from .irrsmo00 import IRRSMO00
 from .logger import Logger
+from .null_response_error import NullResponseError
 from .security_request import SecurityRequest
 from .security_request_error import SecurityRequestError
 from .security_result import SecurityResult
@@ -157,11 +158,11 @@ class SecurityAdmin:
                 security_request.dump_request_xml(encoding="utf-8"),
                 secret_traits=self.__secret_traits,
             )
+        request_xml = self.__logger.redact_request_xml(
+            security_request.dump_request_xml(encoding="utf-8"),
+            secret_traits=self.__secret_traits,
+        )
         if self._generate_requests_only:
-            request_xml = self.__logger.redact_request_xml(
-                security_request.dump_request_xml(encoding="utf-8"),
-                secret_traits=self.__secret_traits,
-            )
             self.__clear_state(security_request)
             return request_xml
         result_xml = self.__logger.redact_result_xml(
@@ -175,6 +176,8 @@ class SecurityAdmin:
             # No need to redact anything here since the raw result XML
             # already has secrets redacted when it is built.
             self.__logger.log_xml("Result XML", result_xml)
+        if result_xml == "":
+            raise NullResponseError(result_xml)
         results = SecurityResult(result_xml)
         if self.__debug:
             # No need to redact anything here since the result dictionary
@@ -189,7 +192,7 @@ class SecurityAdmin:
             # up to the user to interogate the result dictionary attached to the
             # SecurityRequestError and decided whether or not the return code 4 is
             # indicative of a problem.
-            raise SecurityRequestError(result_dictionary)
+            raise SecurityRequestError(result_dictionary, request_xml)
         return result_dictionary
 
     def _to_steps(self, results: Union[List[dict], dict, bytes]) -> Union[dict, bytes]:

--- a/pyracf/common/security_request_error.py
+++ b/pyracf/common/security_request_error.py
@@ -6,9 +6,10 @@ class SecurityRequestError(Exception):
     Raised when the return code of a security result returned by IRRSMO00 is NOT equal to 0.
     """
 
-    def __init__(self, result: dict) -> None:
+    def __init__(self, result: dict, request_xml: str) -> None:
         self.message = "Security request made to IRRSMO00 failed."
-        self.result = result
+        self.request_xml = request_xml
+        self.result = self.__check_result_type(result)
         self.message += (
             "\n\nSee results dictionary "
             + f"'{self.__class__.__name__}.result' for more details."
@@ -18,9 +19,46 @@ class SecurityRequestError(Exception):
     def __str__(self) -> str:
         return self.message
 
+    def __check_result_type(self, result: dict) -> dict:
+        not_profiles = ["returnCode", "reasonCode"]
+        for profile_type in result["securityResult"]:
+            if profile_type in not_profiles:
+                continue
+            if "error" in result["securityResult"][profile_type]:
+                return self.__organize_smo_error(result, profile_type)
+        return result
+
+    def __organize_smo_error(self, result: dict, profile_type: str) -> dict:
+        command_result = {}
+        command_result["image"] = self.request_xml.decode("utf-8")
+        command_result["safReturnCode"] = result["securityResult"][profile_type][
+            "error"
+        ]["errorFunction"]
+        command_result["returnCode"] = result["securityResult"][profile_type]["error"][
+            "errorCode"
+        ]
+        command_result["reasonCode"] = result["securityResult"][profile_type]["error"][
+            "errorReason"
+        ]
+        error_offset = result["securityResult"][profile_type]["error"]["errorOffset"]
+        error_text = result["securityResult"][profile_type]["error"]["textInError"]
+        error_message = (
+            result["securityResult"][profile_type]["error"]["errorMessage"]
+            + "\n"
+            + f"Text in Error: '{error_text}'\n"
+            + f"Approximate Offset of Text in Error: '{error_offset}'\n"
+            + "Please note that for any text in error,"
+            + " redacted values may skew offset calculations."
+        )
+        command_result["messages"] = [error_message]
+        result["securityResult"][profile_type]["commands"] = [command_result]
+        del result["securityResult"][profile_type]["error"]
+        return result
+
     def contains_error_message(
         self, security_definition_tag: str, error_message_id: str
     ):
+        """Checks to see if specific error message id appears in the security request error"""
         commands = self.result["securityResult"][security_definition_tag].get(
             "commands"
         )

--- a/pyracf/scripts/install_precheck.py
+++ b/pyracf/scripts/install_precheck.py
@@ -1,0 +1,34 @@
+from pyracf import ResourceAdmin, SecurityRequestError
+
+
+def define_precheck_profile():
+    resource_admin = ResourceAdmin()
+    try:
+        access = resource_admin.get_my_access("IRR.IRRSMO00.PRECHECK", "XFACILIT")
+    except SecurityRequestError:
+        traits_precheck = {"base:universal_access": "None"}
+        result = resource_admin.add(
+            "IRR.IRRSMO00.PRECHECK", "XFACILIT", traits=traits_precheck
+        )
+        print(
+            "IRR.IRRSMO00.PRECHECK is now defined with a `Universal Access` of None."
+            + "\nContact your security administrator for READ access before using pyRACF."
+            + "\nOther users of pyRACF will also need to have at least read access."
+            + "\nYou may also need to REFRESH the `XFACILIT` class."
+            + "\nReview our documentation at https://ambitus.github.io/pyracf/ as well!"
+        )
+        return result
+    if access:
+        print(
+            f"IRR.IRRSMO00.PRECHECK is already defined, and you already have {access} access!"
+            + "\nYou are ready to start using pyRACF!"
+            + "\nPlease ensure other users of pyRACF also have at least read access."
+            + "\nReview our documentation at https://ambitus.github.io/pyracf/ as well!"
+        )
+        return True
+    print(
+        "IRR.IRRSMO00.PRECHECK is already defined, but you have no access."
+        + "\nContact your security administrator for READ access before using pyRACF."
+        + "\nReview our documentation at https://ambitus.github.io/pyracf/ as well!"
+    )
+    return False

--- a/tests/common/test_common_constants.py
+++ b/tests/common/test_common_constants.py
@@ -1,0 +1,51 @@
+"""
+Sample data for testing General Resource Profile Administration functions.
+"""
+
+from typing import Union
+
+import tests.test_utilities as TestUtilities
+
+
+def get_sample(sample_file: str) -> Union[str, bytes]:
+    return TestUtilities.get_sample(sample_file, "resource")
+
+
+# ============================================================================
+# Install Precheck Sample Data
+# ============================================================================
+
+TEST_EXTRACT_RESOURCE_RESULT_PRECHECK_ERROR_XML = get_sample(
+    "extract_resource_result_precheck_error.xml"
+)
+TEST_EXTRACT_RESOURCE_RESULT_PRECHECK_SUCCESS_XML = get_sample(
+    "extract_resource_result_precheck_success.xml"
+)
+
+TEST_ADD_RESOURCE_PRECHECK_UACC_NONE_SUCCESS_XML = get_sample(
+    "add_resource_result_precheck_uacc_none_success.xml"
+)
+TEST_ADD_RESOURCE_PRECHECK_UACC_NONE_SUCCESS_DICTIONARY = get_sample(
+    "add_resource_result_precheck_uacc_none_success.json"
+)
+
+TEST_INSTALL_PRECHECK_VALIDATED_ACCESS_TEXT = (
+    "IRR.IRRSMO00.PRECHECK is already defined, and you already have alter access!"
+    + "\nYou are ready to start using pyRACF!"
+    + "\nPlease ensure other users of pyRACF also have at least read access."
+    + "\nReview our documentation at https://ambitus.github.io/pyracf/ as well!\n"
+)
+
+TEST_INSTALL_PRECHECK_FOUND_NO_ACCESS_TEXT = (
+    "IRR.IRRSMO00.PRECHECK is already defined, but you have no access."
+    + "\nContact your security administrator for READ access before using pyRACF."
+    + "\nReview our documentation at https://ambitus.github.io/pyracf/ as well!\n"
+)
+
+TEST_INSTALL_PRECHECK_DEFINED_PROFILE_TEXT = (
+    "IRR.IRRSMO00.PRECHECK is now defined with a `Universal Access` of None."
+    + "\nContact your security administrator for READ access before using pyRACF."
+    + "\nOther users of pyRACF will also need to have at least read access."
+    + "\nYou may also need to REFRESH the `XFACILIT` class."
+    + "\nReview our documentation at https://ambitus.github.io/pyracf/ as well!\n"
+)

--- a/tests/common/test_install_precheck_script.py
+++ b/tests/common/test_install_precheck_script.py
@@ -1,0 +1,157 @@
+"""Test password sanitization in resource debug logging."""
+
+import contextlib
+import io
+import re
+import unittest
+from unittest.mock import Mock, patch
+
+import __init__
+
+import tests.common.test_common_constants as TestCommonConstants
+from pyracf import define_precheck_profile
+from pyracf.common.irrsmo00 import IRRSMO00
+
+# Resolves F401
+__init__
+
+
+@patch("pyracf.common.irrsmo00.IRRSMO00.call_racf")
+class TestInstallPrecheckScript(unittest.TestCase):
+    maxDiff = None
+    IRRSMO00.__init__ = Mock(return_value=None)
+    ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+    def test_install_precheck_works_when_no_setup_done(
+        self,
+        call_racf_mock: Mock,
+    ):
+        call_racf_mock.side_effect = [
+            TestCommonConstants.TEST_EXTRACT_RESOURCE_RESULT_PRECHECK_ERROR_XML,
+            TestCommonConstants.TEST_EXTRACT_RESOURCE_RESULT_PRECHECK_ERROR_XML,
+            TestCommonConstants.TEST_ADD_RESOURCE_PRECHECK_UACC_NONE_SUCCESS_XML,
+        ]
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            result = define_precheck_profile()
+        precheck_log = self.ansi_escape.sub("", stdout.getvalue())
+        self.assertEqual(
+            precheck_log, TestCommonConstants.TEST_INSTALL_PRECHECK_DEFINED_PROFILE_TEXT
+        )
+        self.assertEqual(
+            result,
+            TestCommonConstants.TEST_ADD_RESOURCE_PRECHECK_UACC_NONE_SUCCESS_DICTIONARY,
+        )
+
+    def test_install_precheck_works_when_alter_access_exists(
+        self,
+        call_racf_mock: Mock,
+    ):
+        call_racf_mock.return_value = (
+            TestCommonConstants.TEST_EXTRACT_RESOURCE_RESULT_PRECHECK_SUCCESS_XML
+        )
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            result = define_precheck_profile()
+        precheck_log = self.ansi_escape.sub("", stdout.getvalue())
+        self.assertEqual(
+            precheck_log,
+            TestCommonConstants.TEST_INSTALL_PRECHECK_VALIDATED_ACCESS_TEXT,
+        )
+        self.assertEqual(result, True)
+
+    def test_install_precheck_works_when_control_access_exists(
+        self,
+        call_racf_mock: Mock,
+    ):
+        extract_with_control_access = (
+            TestCommonConstants.TEST_EXTRACT_RESOURCE_RESULT_PRECHECK_SUCCESS_XML
+        )
+        extract_with_control_access = extract_with_control_access.replace(
+            "<message> 00    ESWIFT          READ              ALTER    NO</message>",
+            "<message> 00    ESWIFT          READ             CONTROL   NO</message>",
+        )
+        call_racf_mock.return_value = extract_with_control_access
+        validated_control_access = (
+            TestCommonConstants.TEST_INSTALL_PRECHECK_VALIDATED_ACCESS_TEXT
+        )
+        validated_control_access = validated_control_access.replace(
+            "you already have alter access!", "you already have control access!"
+        )
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            result = define_precheck_profile()
+        precheck_log = self.ansi_escape.sub("", stdout.getvalue())
+        self.assertEqual(precheck_log, validated_control_access)
+        self.assertEqual(result, True)
+
+    def test_install_precheck_works_when_read_access_exists(
+        self,
+        call_racf_mock: Mock,
+    ):
+        extract_with_read_access = (
+            TestCommonConstants.TEST_EXTRACT_RESOURCE_RESULT_PRECHECK_SUCCESS_XML
+        )
+        extract_with_read_access = extract_with_read_access.replace(
+            "<message> 00    ESWIFT          READ              ALTER    NO</message>",
+            "<message> 00    ESWIFT          READ              READ     NO</message>",
+        )
+        call_racf_mock.return_value = extract_with_read_access
+        validated_read_access = (
+            TestCommonConstants.TEST_INSTALL_PRECHECK_VALIDATED_ACCESS_TEXT
+        )
+        validated_read_access = validated_read_access.replace(
+            "you already have alter access!", "you already have read access!"
+        )
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            result = define_precheck_profile()
+        precheck_log = self.ansi_escape.sub("", stdout.getvalue())
+        self.assertEqual(precheck_log, validated_read_access)
+        self.assertEqual(result, True)
+
+    def test_install_precheck_works_when_update_access_exists(
+        self,
+        call_racf_mock: Mock,
+    ):
+        extract_with_update_access = (
+            TestCommonConstants.TEST_EXTRACT_RESOURCE_RESULT_PRECHECK_SUCCESS_XML
+        )
+        extract_with_update_access = extract_with_update_access.replace(
+            "<message> 00    ESWIFT          READ              ALTER    NO</message>",
+            "<message> 00    ESWIFT          READ             UPDATE    NO</message>",
+        )
+        call_racf_mock.return_value = extract_with_update_access
+        validated_update_access = (
+            TestCommonConstants.TEST_INSTALL_PRECHECK_VALIDATED_ACCESS_TEXT
+        )
+        validated_update_access = validated_update_access.replace(
+            "you already have alter access!", "you already have update access!"
+        )
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            result = define_precheck_profile()
+        precheck_log = self.ansi_escape.sub("", stdout.getvalue())
+        self.assertEqual(precheck_log, validated_update_access)
+        self.assertEqual(result, True)
+
+    def test_install_precheck_works_when_none_access_exists(
+        self,
+        call_racf_mock: Mock,
+    ):
+        extract_with_none_access = (
+            TestCommonConstants.TEST_EXTRACT_RESOURCE_RESULT_PRECHECK_SUCCESS_XML
+        )
+        extract_with_none_access = extract_with_none_access.replace(
+            "<message> 00    ESWIFT          READ              ALTER    NO</message>",
+            "<message> 00    ESWIFT          READ              NONE     NO</message>",
+        )
+        call_racf_mock.return_value = extract_with_none_access
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            result = define_precheck_profile()
+        precheck_log = self.ansi_escape.sub("", stdout.getvalue())
+        self.assertEqual(
+            precheck_log, TestCommonConstants.TEST_INSTALL_PRECHECK_FOUND_NO_ACCESS_TEXT
+        )
+        self.assertEqual(result, False)

--- a/tests/common/test_null_response_error.py
+++ b/tests/common/test_null_response_error.py
@@ -1,0 +1,34 @@
+"""Test general resource profile result parser."""
+
+import unittest
+from unittest.mock import Mock, patch
+
+import __init__
+
+from pyracf import NullResponseError, UserAdmin
+from pyracf.common.irrsmo00 import IRRSMO00
+
+# Resolves F401
+__init__
+
+
+@patch("pyracf.common.irrsmo00.IRRSMO00.call_racf")
+class TestNullResponseError(unittest.TestCase):
+    maxDiff = None
+    IRRSMO00.__init__ = Mock(return_value=None)
+    user_admin = UserAdmin()
+
+    def test_null_response_error_thrown_on_null_response(
+        self,
+        call_racf_mock: Mock,
+    ):
+        call_racf_mock.return_value = ""
+        with self.assertRaises(NullResponseError) as exception:
+            self.user_admin.set_password("TESTUSER", "Testpass")
+        self.assertEqual(
+            exception.exception.message,
+            "(NullResponseError) Security request made to IRRSMO00 failed."
+            + "\n\nCheck to see if proper RACF permissions are in place.\n"
+            + "For `set` or `alter` functions, you must have at least READ "
+            + "access to `IRR.IRRSMO00.PRECHECK` in the `XFACILIT` class.",
+        )

--- a/tests/group/group_result_samples/add_group_result_error.json
+++ b/tests/group/group_result_samples/add_group_result_error.json
@@ -4,14 +4,17 @@
       "name": "TESTGRPP0",
       "operation": "set",
       "requestId": "GroupRequest",
-      "error": {
-        "errorFunction": 10,
-        "errorCode": 2000,
-        "errorReason": 68,
-        "errorMessage": "Invalid attribute value specified.",
-        "errorOffset": 149,
-        "textInError": "name"
-      }
+      "commands": [
+        {
+          "safReturnCode": 10,
+          "returnCode": 2000,
+          "reasonCode": 68,
+          "image": "<securityrequest xmlns=\"http://www.ibm.com/systems/zos/saf\" xmlns:racf=\"http://www.ibm.com/systems/zos/racf\"><group name=\"TESTGRPP0\" operation=\"set\" requestid=\"GroupRequest\" /></securityrequest>",
+          "messages": [
+            "Invalid attribute value specified.\nText in Error: 'name'\nApproximate Offset of Text in Error: '149'\nPlease note that for any text in error, redacted values may skew offset calculations."
+          ]
+        }
+      ]
     },
     "returnCode": 2000,
     "reasonCode": 68

--- a/tests/group/group_result_samples/extract_group_result_bad_attribute_error.json
+++ b/tests/group/group_result_samples/extract_group_result_bad_attribute_error.json
@@ -4,14 +4,17 @@
       "name": "TESTGRPP0",
       "operation": "listdata",
       "requestId": "GroupRequest",
-      "error": {
-        "errorFunction": 10,
-        "errorCode": 2000,
-        "errorReason": 68,
-        "errorMessage": "Invalid attribute value specified.",
-        "errorOffset": 149,
-        "textInError": "name"
-      }
+      "commands": [
+        {
+          "safReturnCode": 10,
+          "returnCode": 2000,
+          "reasonCode": 68,
+          "image": "<securityrequest xmlns=\"http://www.ibm.com/systems/zos/saf\" xmlns:racf=\"http://www.ibm.com/systems/zos/racf\"><group name=\"TESTGRPP0\" operation=\"listdata\" requestid=\"GroupRequest\" /></securityrequest>",
+          "messages": [
+            "Invalid attribute value specified.\nText in Error: 'name'\nApproximate Offset of Text in Error: '149'\nPlease note that for any text in error, redacted values may skew offset calculations."
+          ]
+        }
+      ]
     },
     "returnCode": 2000,
     "reasonCode": 68

--- a/tests/group/test_group_result_parser.py
+++ b/tests/group/test_group_result_parser.py
@@ -75,6 +75,7 @@ class TestGroupResultParser(unittest.TestCase):
             self.group_admin.add(
                 "TESTGRPP0", traits=TestGroupConstants.TEST_ADD_GROUP_REQUEST_TRAITS
             )
+        print(exception.exception.result)
         self.assertEqual(
             exception.exception.result,
             TestGroupConstants.TEST_EXTRACT_GROUP_RESULT_BAD_ATTRIBUTE_ERROR_DICTIONARY,

--- a/tests/resource/resource_result_samples/add_resource_result_precheck_uacc_none_success.json
+++ b/tests/resource/resource_result_samples/add_resource_result_precheck_uacc_none_success.json
@@ -1,0 +1,32 @@
+{
+  "securityResult": {
+    "resource": {
+      "name": "IRR.IRRSMO00.PRECHECK",
+      "class": "XFACILIT",
+      "operation": "set",
+      "requestId": "ResourceRequest",
+      "commands": [
+        {
+          "safReturnCode": 0,
+          "returnCode": 0,
+          "reasonCode": 0,
+          "image": "RDEFINE XFACILIT             (IRR.IRRSMO00.PRECHECK) ",
+          "messages": [
+            "ICH10006I RACLISTED PROFILES FOR XFACILIT WILL NOT REFLECT THE ADDITION(S) UNTIL A SETROPTS REFRESH IS ISSUED."
+          ]
+        },
+        {
+          "safReturnCode": 0,
+          "returnCode": 0,
+          "reasonCode": 0,
+          "image": "RALTER  XFACILIT             (IRR.IRRSMO00.PRECHECK)  UACC        (None) ",
+          "messages": [
+            "ICH11009I RACLISTED PROFILES FOR XFACILIT WILL NOT REFLECT THE UPDATE(S) UNTIL A SETROPTS REFRESH IS ISSUED."
+          ]
+        }
+      ]
+    },
+    "returnCode": 0,
+    "reasonCode": 0
+  }
+}

--- a/tests/resource/resource_result_samples/add_resource_result_precheck_uacc_none_success.xml
+++ b/tests/resource/resource_result_samples/add_resource_result_precheck_uacc_none_success.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="IBM-1047"?>
+<securityresult xmlns="http://www.ibm.com/systems/zos/saf/IRRSMO00Result1">
+  <resource name="IRR.IRRSMO00.PRECHECK" class="XFACILIT" operation="set" requestid="ResourceRequest">
+    <command>
+      <safreturncode>0</safreturncode>
+      <returncode>0</returncode>
+      <reasoncode>0</reasoncode>
+      <image>RDEFINE XFACILIT             (IRR.IRRSMO00.PRECHECK) </image>
+      <message>ICH10006I RACLISTED PROFILES FOR XFACILIT WILL NOT REFLECT THE ADDITION(S) UNTIL A SETROPTS REFRESH IS ISSUED.</message>
+    </command>
+    <command>
+      <safreturncode>0</safreturncode>
+      <returncode>0</returncode>
+      <reasoncode>0</reasoncode>
+      <image>RALTER  XFACILIT             (IRR.IRRSMO00.PRECHECK)  UACC        (None) </image>
+      <message>ICH11009I RACLISTED PROFILES FOR XFACILIT WILL NOT REFLECT THE UPDATE(S) UNTIL A SETROPTS REFRESH IS ISSUED.</message>
+    </command>
+  </resource>
+  <returncode>0</returncode>
+  <reasoncode>0</reasoncode>
+</securityresult>

--- a/tests/resource/resource_result_samples/extract_resource_result_precheck_error.xml
+++ b/tests/resource/resource_result_samples/extract_resource_result_precheck_error.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="IBM-1047"?>
+<securityresult xmlns="http://www.ibm.com/systems/zos/saf/IRRSMO00Result1">
+  <resource name="IRR.IRRSMO00.PRECHECK" class="XFACILIT" operation="listdata" requestid="ResourceRequest">
+    <command>
+      <safreturncode>8</safreturncode>
+      <returncode>16</returncode>
+      <reasoncode>4</reasoncode>
+      <image>RLIST   XFACILIT             (IRR.IRRSMO00.PRECHECK) </image>
+      <message>ICH13003I TESTING NOT FOUND</message>
+    </command>
+  </resource>
+  <returncode>4</returncode>
+  <reasoncode>0</reasoncode>
+</securityresult>

--- a/tests/resource/resource_result_samples/extract_resource_result_precheck_success.xml
+++ b/tests/resource/resource_result_samples/extract_resource_result_precheck_success.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="IBM-1047"?>
+<securityresult xmlns="http://www.ibm.com/systems/zos/saf/IRRSMO00Result1">
+  <resource name="IRR.IRRSMO00.PRECHECK" class="XFACILIT" operation="listdata" requestid="ResourceRequest">
+    <command>
+      <safreturncode>0</safreturncode>
+      <returncode>0</returncode>
+      <reasoncode>0</reasoncode>
+      <image>RLIST   XFACILIT             (IRR.IRRSMO00.PRECHECK) </image>
+      <message>CLASS      NAME</message>
+      <message>-----      ----</message>
+      <message>XFACILIT   IRR.IRRSMO00.PRECHECK</message>
+      <message> </message>
+      <message>GROUP CLASS NAME</message>
+      <message>----- ----- ----</message>
+      <message>GXFACILI</message>
+      <message> </message>
+      <message>LEVEL  OWNER      UNIVERSAL ACCESS  YOUR ACCESS  WARNING</message>
+      <message>-----  --------   ----------------  -----------  -------</message>
+      <message> 00    ESWIFT          READ              ALTER    NO</message>
+      <message> </message>
+      <message>INSTALLATION DATA</message>
+      <message>-----------------</message>
+      <message>NONE</message>
+      <message> </message>
+      <message>APPLICATION DATA</message>
+      <message>----------------</message>
+      <message>NONE</message>
+      <message> </message>
+      <message>AUDITING</message>
+      <message>--------</message>
+      <message>FAILURES(READ)</message>
+      <message> </message>
+      <message>NOTIFY</message>
+      <message>------</message>
+      <message>NO USER TO BE NOTIFIED</message>
+    </command>
+  </resource>
+  <returncode>0</returncode>
+  <reasoncode>0</reasoncode>
+</securityresult>

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -8,7 +8,9 @@ import __init__
 from tests.access.test_access_debug_logging import TestAccessDebugLogging
 from tests.access.test_access_request_builder import TestAccessRequestBuilder
 from tests.access.test_access_result_parser import TestAccessResultParser
+from tests.common.test_install_precheck_script import TestInstallPrecheckScript
 from tests.common.test_logger import TestLogger
+from tests.common.test_null_response_error import TestNullResponseError
 from tests.connection.test_connection_debug_logging import TestConnectionDebugLogging
 from tests.connection.test_connection_request_builder import (
     TestConnectionRequestBuilder,
@@ -59,7 +61,9 @@ def __test_suite() -> unittest.TestSuite:
         TestAccessResultParser,
         TestAccessRequestBuilder,
         TestAccessDebugLogging,
+        TestInstallPrecheckScript,
         TestLogger,
+        TestNullResponseError,
         TestConnectionResultParser,
         TestConnectionRequestBuilder,
         TestConnectionSetters,

--- a/tests/user/user_result_samples/add_user_result_error.json
+++ b/tests/user/user_result_samples/add_user_result_error.json
@@ -4,14 +4,17 @@
       "name": "squidward",
       "operation": "set",
       "requestId": "UserRequest",
-      "error": {
-        "errorFunction": 10,
-        "errorCode": 2000,
-        "errorReason": 68,
-        "errorMessage": "Invalid attribute value specified.",
-        "errorOffset": 149,
-        "textInError": "name"
-      }
+      "commands": [
+        {
+          "safReturnCode": 10,
+          "returnCode": 2000,
+          "reasonCode": 68,
+          "image": "<securityrequest xmlns=\"http://www.ibm.com/systems/zos/saf\" xmlns:racf=\"http://www.ibm.com/systems/zos/racf\"><user name=\"squidward\" operation=\"set\" requestid=\"UserRequest\" /></securityrequest>",
+          "messages": [
+            "Invalid attribute value specified.\nText in Error: 'name'\nApproximate Offset of Text in Error: '149'\nPlease note that for any text in error, redacted values may skew offset calculations."
+          ]
+        }
+      ]
     },
     "returnCode": 2000,
     "reasonCode": 68

--- a/tests/user/user_result_samples/extract_user_result_bad_attribute_error.json
+++ b/tests/user/user_result_samples/extract_user_result_bad_attribute_error.json
@@ -4,14 +4,17 @@
       "name": "squidward",
       "operation": "listdata",
       "requestId": "UserRequest",
-      "error": {
-        "errorFunction": 10,
-        "errorCode": 2000,
-        "errorReason": 68,
-        "errorMessage": "Invalid attribute value specified.",
-        "errorOffset": 149,
-        "textInError": "name"
-      }
+      "commands": [
+        {
+          "safReturnCode": 10,
+          "returnCode": 2000,
+          "reasonCode": 68,
+          "image": "<securityrequest xmlns=\"http://www.ibm.com/systems/zos/saf\" xmlns:racf=\"http://www.ibm.com/systems/zos/racf\"><user name=\"squidward\" operation=\"listdata\" requestid=\"UserRequest\" /></securityrequest>",
+          "messages": [
+            "Invalid attribute value specified.\nText in Error: 'name'\nApproximate Offset of Text in Error: '149'\nPlease note that for any text in error, redacted values may skew offset calculations."
+          ]
+        }
+      ]
     },
     "returnCode": 2000,
     "reasonCode": 68


### PR DESCRIPTION
-Standardize SecurityRequestError Structure, merging IRRSMO00 Errors and that of RACF Errors with the smae internal structure in the result dictionary
-Add an install script that defines IRR.IRRSMO00.PRECHECK with UACC of none and/or checks if the profile exists and the current user's access -Added NullResponseError
-Added Unit Testing for Install script and null response error

### :bulb: 

**Issue:**  #44 #48 #52 

### :computer: What does this address?

Addresses listed issues in pyRACF's error handling and associated processing.
1) Adds new error for Null Response from IRRSMO00
2) Standardizes SecurityRequestError structure
3) Adds "install script" to define/check authorizations for IRR.IRRSMO00.PRECHECK

### :pager: Implementation Details

1) Checked for null string response from IRRSMO00 and throw new error if so
2) Define new methods of SecurityRequestError to restructure IRRSMO00 response XML with IRRSMO00 error to more closely align with RACF-error structure
3) Added "Scripts" folder and defined externally available function that checks active user's access to IRR.IRRSMO00.PRECHECK and creates the resource if possible.

### :clipboard: Is there a test case?

Designed new test cases for new error and install script under "common" test cases. Tested new SecurityRequestError functions with existing user and group error tests
