### PR TITLE
Add optional Expired/Noexpired

### DIFF
--- a/pyracf/data_set/data_set_admin.py
+++ b/pyracf/data_set/data_set_admin.py
@@ -140,8 +140,8 @@ class DataSetAdmin(SecurityAdmin):
             profile = self.extract(
                 data_set, volume=volume, generic=generic, profile_only=True
             )
-        except SecurityRequestError:
-            raise AlterOperationError(data_set, self._profile_type)
+        except SecurityRequestError as exception:
+            raise AlterOperationError(data_set, self._profile_type) from exception
         if not self._get_field(profile, "base", "name") == data_set.lower():
             raise AlterOperationError(data_set, self._profile_type)
         self._build_segment_trait_dictionary(traits)

--- a/pyracf/group/group_admin.py
+++ b/pyracf/group/group_admin.py
@@ -147,8 +147,8 @@ class GroupAdmin(SecurityAdmin):
             return self._make_request(group_request, irrsmo00_precheck=True)
         try:
             self.extract(group)
-        except SecurityRequestError:
-            raise AlterOperationError(group, self._profile_type)
+        except SecurityRequestError as exception:
+            raise AlterOperationError(group, self._profile_type) from exception
         self._build_segment_trait_dictionary(traits)
         group_request = GroupRequest(group, "set")
         self._build_xml_segments(group_request, alter=True)

--- a/pyracf/resource/resource_admin.py
+++ b/pyracf/resource/resource_admin.py
@@ -512,8 +512,8 @@ class ResourceAdmin(SecurityAdmin):
             return self._make_request(profile_request, irrsmo00_precheck=True)
         try:
             profile = self.extract(resource, class_name, profile_only=True)
-        except SecurityRequestError:
-            raise AlterOperationError(resource, class_name)
+        except SecurityRequestError as exception:
+            raise AlterOperationError(resource, class_name) from exception
         if not self._get_field(profile, "base", "name") == resource.lower():
             raise AlterOperationError(resource, class_name)
         self._build_segment_trait_dictionary(traits)

--- a/tests/user/test_user_constants.py
+++ b/tests/user/test_user_constants.py
@@ -251,8 +251,14 @@ TEST_USER_REMOVE_OPERATIONS_AUTHORITY_XML = get_sample(
     "user_remove_operations_authority_request.xml"
 )
 TEST_USER_SET_PASSWORD_XML = get_sample("user_set_password_request.xml")
+TEST_USER_SET_PASSWORD_NOEXPIRED_XML = get_sample(
+    "user_set_password_noexpired_request.xml"
+)
 TEST_USER_SET_PASSWORD_DELETE_XML = get_sample("user_set_password_delete_request.xml")
 TEST_USER_SET_PASSPHRASE_XML = get_sample("user_set_passphrase_request.xml")
+TEST_USER_SET_PASSPHRASE_NOEXPIRED_XML = get_sample(
+    "user_set_passphrase_noexpired_request.xml"
+)
 TEST_USER_SET_PASSPHRASE_DELETE_XML = get_sample(
     "user_set_passphrase_delete_request.xml"
 )

--- a/tests/user/test_user_setters.py
+++ b/tests/user/test_user_setters.py
@@ -68,6 +68,10 @@ class TestUserSetters(unittest.TestCase):
         result = self.user_admin.set_password("squidwrd", "GIyTTqdF")
         self.assertEqual(result, TestUserConstants.TEST_USER_SET_PASSWORD_XML)
 
+    def test_user_admin_build_set_password_noexpired_request(self):
+        result = self.user_admin.set_password("squidwrd", "GIyTTqdF", expired=False)
+        self.assertEqual(result, TestUserConstants.TEST_USER_SET_PASSWORD_NOEXPIRED_XML)
+
     def test_user_admin_build_set_password_delete_request(self):
         result = self.user_admin.set_password("squidwrd", False)
         self.assertEqual(result, TestUserConstants.TEST_USER_SET_PASSWORD_DELETE_XML)
@@ -78,6 +82,14 @@ class TestUserSetters(unittest.TestCase):
     def test_user_admin_build_set_passphrase_request(self):
         result = self.user_admin.set_passphrase("squidwrd", "PassPhrasesAreCool!")
         self.assertEqual(result, TestUserConstants.TEST_USER_SET_PASSPHRASE_XML)
+
+    def test_user_admin_build_set_passphrase_noexpired_request(self):
+        result = self.user_admin.set_passphrase(
+            "squidwrd", "PassPhrasesAreCool!", expired=False
+        )
+        self.assertEqual(
+            result, TestUserConstants.TEST_USER_SET_PASSPHRASE_NOEXPIRED_XML
+        )
 
     def test_user_admin_build_set_passphrase_delete_request(self):
         result = self.user_admin.set_passphrase("squidwrd", False)

--- a/tests/user/user_request_samples/user_set_passphrase_noexpired_request.xml
+++ b/tests/user/user_request_samples/user_set_passphrase_noexpired_request.xml
@@ -1,8 +1,8 @@
 <securityrequest xmlns="http://www.ibm.com/systems/zos/saf" xmlns:racf="http://www.ibm.com/systems/zos/racf">
   <user name="squidwrd" operation="set" requestid="UserRequest">
     <base>
-      <racf:password operation="set">********</racf:password>
-      <racf:expired operation="set" />
+      <racf:phrase operation="set">********</racf:phrase>
+      <racf:expired operation="del" />
     </base>
   </user>
 </securityrequest>

--- a/tests/user/user_request_samples/user_set_passphrase_request.xml
+++ b/tests/user/user_request_samples/user_set_passphrase_request.xml
@@ -2,6 +2,7 @@
   <user name="squidwrd" operation="set" requestid="UserRequest">
     <base>
       <racf:phrase operation="set">********</racf:phrase>
+      <racf:expired operation="set" />
     </base>
   </user>
 </securityrequest>

--- a/tests/user/user_request_samples/user_set_password_noexpired_request.xml
+++ b/tests/user/user_request_samples/user_set_password_noexpired_request.xml
@@ -2,7 +2,7 @@
   <user name="squidwrd" operation="set" requestid="UserRequest">
     <base>
       <racf:password operation="set">********</racf:password>
-      <racf:expired operation="set" />
+      <racf:expired operation="del" />
     </base>
   </user>
 </securityrequest>


### PR DESCRIPTION
-Add optional parameter to set_password and set_passphrase that allows for user passwords and phrases to be set noexpired

### :bulb: Issue Reference

**Issue:**  #49 

### :computer: What does this address?

Admins setting user passwords or phrases may want to make them non-expired, which is not possible except with UserAdmin.alter() right now.

### :pager: Implementation Details

Added an optional argument to set_password and set_passphrase that emulates RACF defaults anyway (setting a password without NOEXPIRED will make the password EXPIRED by default).

### :clipboard: Is there a test case?

Made 2 new testcases to test setting noexpired with password and password phrase

*Either include the path to the test case file, or details on a manual test*