### PR TITLE
Change Dependency Note references for Surrogat Access

### DIFF
--- a/common/class_attributes/run_as_userid.md
+++ b/common/class_attributes/run_as_userid.md
@@ -17,7 +17,7 @@ Make security requests as another user.
 &nbsp;
 
 {: .warning}
-> _In order to use **Run as Userid**, the caller must have at least `UPDATE` access to the `userid.IRRSMO00` resource in the `SURROGAT` class, where `userid` represents the specific userid you wish to execute commands as. Further information can be found outlined in [Our Dependencies Note](../../../index)._
+> _In order to use **Run as Userid**, the caller must have at least `UPDATE` access to the `userid.IRRSMO00` resource in the `SURROGAT` class, where `userid` represents the specific userid you wish to execute commands as. Details for all authorizations for IRRSMO00 can be found [here](https://www.ibm.com/docs/en/zos/3.1.0?topic=operations-racf-authorization)._
 
 &nbsp;
 

--- a/common/class_attributes/run_as_userid.md
+++ b/common/class_attributes/run_as_userid.md
@@ -17,7 +17,7 @@ Make security requests as another user.
 &nbsp;
 
 {: .warning}
-> _In order to use **Run as Userid**, the caller must have at least `UPDATE` access to the `userid.IRRSMO00` resource in the `SURROGAT` class, where `userid` represents the specific userid you wish to execute commands as. Details for all authorizations for IRRSMO00 can be found [here](https://www.ibm.com/docs/en/zos/3.1.0?topic=operations-racf-authorization)._
+> _In order to use **Run as Userid**, the caller must have at least `UPDATE` access to the `userid.IRRSMO00` resource in the `SURROGAT` class, where `userid` represents the specific userid you wish to execute commands as. More information about IRRSMO00 authorizations can be found [here](https://www.ibm.com/docs/en/zos/3.1.0?topic=operations-racf-authorization)._
 
 &nbsp;
 

--- a/resource/abstractions/individual_access.md
+++ b/resource/abstractions/individual_access.md
@@ -57,7 +57,7 @@ def get_user_access(self, resource: str, class_name: str, userid: str) -> Union[
 &nbsp;
 
 {:.warning}
-> _In order to use `get_user_access`, the caller must have at least `UPDATE` access to the `userid.IRRSMO00` resource in the `SURROGAT` class, where `userid` represents the specific userid you wish to check access for. Further information can be found outlined in [Our Dependencies Note](../../../index)._
+> _In order to use `get_user_access`, the caller must have at least `UPDATE` access to the `userid.IRRSMO00` resource in the `SURROGAT` class, where `userid` represents the specific userid you wish to check access for. Details for all authorizations for IRRSMO00 can be found [here](https://www.ibm.com/docs/en/zos/3.1.0?topic=operations-racf-authorization)._
 
 &nbsp;
 

--- a/resource/abstractions/individual_access.md
+++ b/resource/abstractions/individual_access.md
@@ -57,7 +57,7 @@ def get_user_access(self, resource: str, class_name: str, userid: str) -> Union[
 &nbsp;
 
 {:.warning}
-> _In order to use `get_user_access`, the caller must have at least `UPDATE` access to the `userid.IRRSMO00` resource in the `SURROGAT` class, where `userid` represents the specific userid you wish to check access for. Details for all authorizations for IRRSMO00 can be found [here](https://www.ibm.com/docs/en/zos/3.1.0?topic=operations-racf-authorization)._
+> _In order to use `get_user_access`, the caller must have at least `UPDATE` access to the `userid.IRRSMO00` resource in the `SURROGAT` class, where `userid` represents the specific userid you wish to check access for. More information about IRRSMO00 authorizations can be found [here](https://www.ibm.com/docs/en/zos/3.1.0?topic=operations-racf-authorization)._
 
 &nbsp;
 


### PR DESCRIPTION
### :bulb: Issue Reference

**Issue:**  N/A

### :computer: What does this address?

Documentation points to "Our Dependencies Note" for discussion about SURROGAT profile access for functions that leverage running commands as another userid. There is no information about this in the note, and we should reference the IRRSMO00 documentation directly here for more information.

### :pager: Implementation Details

N/A

### :clipboard: Is there a test case?

N/A Doc update
