### PR TITLE
Feature/redrive on buffer too small error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
     name="pyracf"
-    version="1.0b5"
+    version="1.0b6"
     description="Python interface to RACF using IRRSMO00 RACF Callable Service."
     license = "Apache-2.0"
     authors = [

--- a/pyracf/common/irrsmo00.c
+++ b/pyracf/common/irrsmo00.c
@@ -25,18 +25,16 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
 
     static char *kwlist[] = {
         "request_xml",
-        "request_xml_length",
         "result_buffer_size",
         "irrsmo00_options",
         "running_userid",
-        "running_userid_length",
         NULL};
 
     if (
         !PyArg_ParseTupleAndKeywords(
             args,
             kwargs,
-            "y|IIIyb",
+            "y#|IIy#",
             kwlist,
             &request_xml,
             &request_xml_length,
@@ -122,12 +120,12 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
     // Py_BuildValue() will return a Tuple.
 
     return Py_BuildValue(
-        "y#BBB", 
-        result_buffer, 
-        result_buffer_size, 
-        saf_rc, 
-        racf_rc, 
-        racf_rsn);
+        "{s:y#,s:I,s:B,s:B,s:B}", 
+        "resultBuffer", result_buffer, result_buffer_size,
+        "handlePointer", req_handle,
+        "safReturnCode", saf_rc, 
+        "racfReturnCode", racf_rc, 
+        "racfReasonCode", racf_rsn);
 }
 
 static char call_irrsmo00_docs[] =

--- a/pyracf/common/irrsmo00.c
+++ b/pyracf/common/irrsmo00.c
@@ -25,16 +25,18 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
 
     static char *kwlist[] = {
         "request_xml",
+        "request_xml_len",
         "result_buffer_size",
         "irrsmo00_options",
         "running_userid",
+        "running_userid_len",
         NULL};
 
     if (
         !PyArg_ParseTupleAndKeywords(
             args,
             kwargs,
-            "y#|IIy#",
+            "y|IIIyb",
             kwlist,
             &request_xml,
             &request_xml_length,
@@ -46,24 +48,26 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     }
 
+    PyObject * full_result;
     char work_area[1024];
-    char req_handle[64] = {0};
+    unsigned char req_handle[64] = {0};
     running_userid_t running_userid_struct = {running_userid_length, {0}};
     unsigned int alet = 0;
     unsigned int acee = 0;
-    unsigned char result_buffer[result_buffer_size];
+    unsigned char * result_buffer = malloc(result_buffer_size);
     memset(result_buffer, 0, result_buffer_size);
     unsigned int saf_rc = 0;
     unsigned int racf_rc = 0;
     unsigned int racf_rsn = 0;
+    unsigned int result_len = result_buffer_size;
     unsigned int num_parms = 17;
-    unsigned int fn = 1; 
+    unsigned int fn = 1;
 
     strncpy(
         running_userid_struct.running_userid, 
         running_userid, 
         running_userid_struct.running_userid_length);
-
+    
     IRRSMO64(
         work_area,
         alet,
@@ -80,8 +84,43 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
         req_handle,
         running_userid_struct,
         acee,
-        result_buffer_size,
+        &result_len,
         result_buffer);
+
+    // Use a PyList Structure to accumulate "bytes" objects of result_buffers
+    full_result = PyList_New(1);
+    PyList_SetItem(full_result, 0, Py_BuildValue("y#", result_buffer, result_len));
+
+    if ((saf_rc == 8) && (racf_rc == 4000) && (racf_rsn < (100000000 - result_buffer_size))){
+        free(result_buffer);
+        result_len = racf_rsn;
+        result_buffer = malloc(result_len);
+        memset(result_buffer, 0, result_len);
+
+        // Call IRRSMO64 Again with the appropriate buffer size
+        IRRSMO64(
+            work_area,
+            alet,
+            &saf_rc,
+            alet,
+            &racf_rc,
+            alet,
+            &racf_rsn,
+            num_parms,
+            fn,
+            irrsmo00_options,
+            request_xml_length,
+            request_xml,
+            req_handle,
+            running_userid_struct,
+            acee,
+            &result_len,
+            result_buffer);
+
+        PyList_Append(full_result, Py_BuildValue("y#", result_buffer, result_len));
+    }
+
+    free(result_buffer);
 
     // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
     //
@@ -120,12 +159,9 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
     // Py_BuildValue() will return a Tuple.
 
     return Py_BuildValue(
-        "{s:y#,s:I,s:B,s:B,s:B}", 
-        "resultBuffer", result_buffer, result_buffer_size,
-        "handlePointer", req_handle,
-        "safReturnCode", saf_rc, 
-        "racfReturnCode", racf_rc, 
-        "racfReasonCode", racf_rsn);
+        "{s:O,s:[B,B,B]}", 
+        "resultBuffers", full_result,
+        "returnCodes", saf_rc, racf_rc, racf_rsn);
 }
 
 static char call_irrsmo00_docs[] =
@@ -136,7 +172,7 @@ static char call_irrsmo00_docs[] =
     "    irrsmo00_options: uint,\n"
     "    running_userid: bytes,\n"
     "    running_userid_length: uint,\n"
-    ") -> List[bytes,int,int,int]:\n"
+    ") -> Dict{ resultBuffers: List[bytes], returnCodes: List[int,int,int] }:\n"
     "# Returns an XML result string and return and reason "
     "codes from the IRRSMO00 RACF Callable Service.\n";
 

--- a/pyracf/common/irrsmo00.c
+++ b/pyracf/common/irrsmo00.c
@@ -29,16 +29,16 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
         "request_xml_len",
         "result_buffer_size",
         "irrsmo00_options",
+        "handle",
         "running_userid",
         "running_userid_len",
-        "handle",
         NULL};
 
     if (
         !PyArg_ParseTupleAndKeywords(
             args,
             kwargs,
-            "yIIIy|yb",
+            "yIII|yyb",
             kwlist,
             &request_xml,
             &request_xml_length,
@@ -89,40 +89,6 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
         &result_len,
         result_buffer);
 
-    // Use a PyList Structure to accumulate "bytes" objects of result_buffers
-    full_result = PyList_New(1);
-    PyList_SetItem(full_result, 0, Py_BuildValue("y#", result_buffer, result_len));
-
-    if ((saf_rc == 8) && (racf_rc == 4000) && (racf_rsn < 100000000)){
-        free(result_buffer);
-        result_len = racf_rsn;
-        result_buffer = malloc(result_len);
-        memset(result_buffer, 0, result_len);
-
-        // Call IRRSMO64 Again with the appropriate buffer size
-        IRRSMO64(
-            work_area,
-            alet,
-            &saf_rc,
-            alet,
-            &racf_rc,
-            alet,
-            &racf_rsn,
-            num_parms,
-            fn,
-            irrsmo00_options,
-            request_xml_length,
-            request_xml,
-            new_req_handle,
-            running_userid_struct,
-            acee,
-            &result_len,
-            result_buffer);
-
-        PyList_Append(full_result, Py_BuildValue("y#", result_buffer, result_len));
-    }
-
-    free(result_buffer);
 
     // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
     //

--- a/pyracf/common/irrsmo00.c
+++ b/pyracf/common/irrsmo00.c
@@ -91,7 +91,7 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
     full_result = PyList_New(1);
     PyList_SetItem(full_result, 0, Py_BuildValue("y#", result_buffer, result_len));
 
-    if ((saf_rc == 8) && (racf_rc == 4000) && (racf_rsn < (100000000 - result_buffer_size))){
+    if ((saf_rc == 8) && (racf_rc == 4000) && (racf_rsn < 100000000)){
         free(result_buffer);
         result_len = racf_rsn;
         result_buffer = malloc(result_len);

--- a/pyracf/common/irrsmo00.c
+++ b/pyracf/common/irrsmo00.c
@@ -38,7 +38,7 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
         !PyArg_ParseTupleAndKeywords(
             args,
             kwargs,
-            "yIII|yyb",
+            "yIII|wyb",
             kwlist,
             &request_xml,
             &request_xml_length,
@@ -127,7 +127,7 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
     // Py_BuildValue() will return a Tuple.
 
     return Py_BuildValue(
-        "{s:y#,s:[B,B,B],s:y#}", 
+        "{s:y#,s:[B,B,B],s:w#}", 
         "resultBuffer", result_buffer, result_len,
         "returnCodes", saf_rc, racf_rc, racf_rsn,
         "handle", request_handle, 64);

--- a/pyracf/common/irrsmo00.c
+++ b/pyracf/common/irrsmo00.c
@@ -20,6 +20,7 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
     const unsigned int request_xml_length;
     const unsigned int result_buffer_size;
     const unsigned int irrsmo00_options;
+    const char request_handle[64] = {0};
     const char *running_userid;
     const uint8_t running_userid_length;
 
@@ -30,18 +31,20 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
         "irrsmo00_options",
         "running_userid",
         "running_userid_len",
+        "handle",
         NULL};
 
     if (
         !PyArg_ParseTupleAndKeywords(
             args,
             kwargs,
-            "y|IIIyb",
+            "yIIIy|yb",
             kwlist,
             &request_xml,
             &request_xml_length,
             &result_buffer_size,
             &irrsmo00_options,
+            &request_handle,
             &running_userid,
             &running_userid_length))
     {
@@ -49,15 +52,14 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     char work_area[1024];
-    unsigned char req_handle[64] = {0};
     running_userid_t running_userid_struct = {running_userid_length, {0}};
     unsigned int alet = 0;
     unsigned int acee = 0;
     unsigned char result_buffer[result_buffer_size];
     memset(result_buffer, 0, result_buffer_size);
-    unsigned int saf_rc = 8;
-    unsigned int racf_rc = 4000;
-    unsigned int racf_rsn = 85771;
+    unsigned int saf_rc = 0;
+    unsigned int racf_rc = 0;
+    unsigned int racf_rsn = 0;
     unsigned int result_len = result_buffer_size;
     unsigned int num_parms = 17;
     unsigned int fn = 1;
@@ -90,7 +92,7 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
         irrsmo00_options,
         request_xml_length,
         request_xml,
-        req_handle,
+        request_handle,
         running_userid_struct,
         acee,
         &result_len,
@@ -144,9 +146,10 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
     // Py_BuildValue() will return a Tuple.
 
     return Py_BuildValue(
-        "{s:y#,s:[B,B,B]}", 
+        "{s:y#,s:[B,B,B],s:y}", 
         "resultBuffer", result_buffer, result_len,
-        "returnCodes", saf_rc, racf_rc, racf_rsn);
+        "returnCodes", saf_rc, racf_rc, racf_rsn,
+        "handle",request_handle);
 }
 
 static char call_irrsmo00_docs[] =

--- a/pyracf/common/irrsmo00.c
+++ b/pyracf/common/irrsmo00.c
@@ -38,7 +38,7 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
         !PyArg_ParseTupleAndKeywords(
             args,
             kwargs,
-            "yIII|wyb",
+            "yIII|w*yb",
             kwlist,
             &request_xml,
             &request_xml_length,
@@ -127,10 +127,10 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
     // Py_BuildValue() will return a Tuple.
 
     return Py_BuildValue(
-        "{s:y#,s:[B,B,B],s:w#}", 
+        "{s:y#,s:[B,B,B],s:w*}", 
         "resultBuffer", result_buffer, result_len,
         "returnCodes", saf_rc, racf_rc, racf_rsn,
-        "handle", request_handle, 64);
+        "handle", request_handle);
 }
 
 static char call_irrsmo00_docs[] =

--- a/pyracf/common/irrsmo00.c
+++ b/pyracf/common/irrsmo00.c
@@ -127,10 +127,10 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
     // Py_BuildValue() will return a Tuple.
 
     return Py_BuildValue(
-        "{s:y#,s:[B,B,B],s:y}", 
+        "{s:y#,s:[B,B,B],s:y#}", 
         "resultBuffer", result_buffer, result_len,
         "returnCodes", saf_rc, racf_rc, racf_rsn,
-        "handle",request_handle);
+        "handle", request_handle, 64);
 }
 
 static char call_irrsmo00_docs[] =

--- a/pyracf/common/irrsmo00.c
+++ b/pyracf/common/irrsmo00.c
@@ -48,20 +48,29 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     }
 
-    PyObject * full_result;
     char work_area[1024];
     unsigned char req_handle[64] = {0};
     running_userid_t running_userid_struct = {running_userid_length, {0}};
     unsigned int alet = 0;
     unsigned int acee = 0;
-    unsigned char * result_buffer = malloc(result_buffer_size);
+    unsigned char result_buffer[result_buffer_size];
     memset(result_buffer, 0, result_buffer_size);
-    unsigned int saf_rc = 0;
-    unsigned int racf_rc = 0;
-    unsigned int racf_rsn = 0;
+    unsigned int saf_rc = 8;
+    unsigned int racf_rc = 4000;
+    unsigned int racf_rsn = 85771;
     unsigned int result_len = result_buffer_size;
     unsigned int num_parms = 17;
     unsigned int fn = 1;
+
+    printf("Before Call!!!!!!!!!!!!!!!!!!!!\n");
+    printf("Request XML: %s\n", request_xml);
+    printf("Request XML Length: %d\n", request_xml_length);
+    printf("Handle value: %s\n", req_handle);
+    printf("Handle Address: %d\n", &req_handle);
+    printf("Result Buffer Size: %d\n",result_buffer_size);
+    printf("Result Buffer Address: %d\n",&result_buffer);
+    printf("Result Buffer Contents: %s\n",result_buffer);
+    printf("Result Buffer Len: %d\n",result_len);
 
     strncpy(
         running_userid_struct.running_userid, 
@@ -87,40 +96,16 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
         &result_len,
         result_buffer);
 
-    // Use a PyList Structure to accumulate "bytes" objects of result_buffers
-    full_result = PyList_New(1);
-    PyList_SetItem(full_result, 0, Py_BuildValue("y#", result_buffer, result_len));
 
-    if ((saf_rc == 8) && (racf_rc == 4000) && (racf_rsn < 100000000)){
-        free(result_buffer);
-        result_len = racf_rsn;
-        result_buffer = malloc(result_len);
-        memset(result_buffer, 0, result_len);
-
-        // Call IRRSMO64 Again with the appropriate buffer size
-        IRRSMO64(
-            work_area,
-            alet,
-            &saf_rc,
-            alet,
-            &racf_rc,
-            alet,
-            &racf_rsn,
-            num_parms,
-            fn,
-            irrsmo00_options,
-            request_xml_length,
-            request_xml,
-            req_handle,
-            running_userid_struct,
-            acee,
-            &result_len,
-            result_buffer);
-
-        PyList_Append(full_result, Py_BuildValue("y#", result_buffer, result_len));
-    }
-
-    free(result_buffer);
+    printf("After Call!!!!!!!!!!!!!!!!!!!!\n");
+    printf("Request XML: %s\n", request_xml);
+    printf("Request XML Length: %d\n", request_xml_length);
+    printf("Handle value: %s\n", req_handle);
+    printf("Handle Address: %d\n", &req_handle);
+    printf("Result Buffer Size: %d\n",result_buffer_size);
+    printf("Result Buffer Address: %d\n",&result_buffer);
+    printf("Result Buffer Contents: %s\n",result_buffer);
+    printf("Result Buffer Len: %d\n",result_len);
 
     // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
     //
@@ -159,8 +144,8 @@ static PyObject *call_irrsmo00(PyObject *self, PyObject *args, PyObject *kwargs)
     // Py_BuildValue() will return a Tuple.
 
     return Py_BuildValue(
-        "{s:O,s:[B,B,B]}", 
-        "resultBuffers", full_result,
+        "{s:y#,s:[B,B,B]}", 
+        "resultBuffer", result_buffer, result_len,
         "returnCodes", saf_rc, racf_rc, racf_rsn);
 }
 
@@ -172,7 +157,7 @@ static char call_irrsmo00_docs[] =
     "    irrsmo00_options: uint,\n"
     "    running_userid: bytes,\n"
     "    running_userid_length: uint,\n"
-    ") -> Dict{ resultBuffers: List[bytes], returnCodes: List[int,int,int] }:\n"
+    ") -> Dict{ resultBuffer: bytes, returnCodes: List[int,int,int] }:\n"
     "# Returns an XML result string and return and reason "
     "codes from the IRRSMO00 RACF Callable Service.\n";
 

--- a/pyracf/common/irrsmo00.py
+++ b/pyracf/common/irrsmo00.py
@@ -67,10 +67,25 @@ class IRRSMO00:
             running_userid=running_userid,
             running_userid_len=len(running_userid),
         )
+        if (
+            (result["returnCodes"][0] == 8)
+            and (result["returnCodes"][1] == 4000)
+            and (result["returnCodes"][2] < 100000000)
+        ):
+            print(result)
+            result = call_irrsmo00(
+                request_xml=request_xml,
+                request_xml_len=len(request_xml),
+                result_buffer_size=result["returnCodes"][2],
+                irrsmo00_options=irrsmo00_options,
+                running_userid=running_userid,
+                running_userid_len=len(running_userid),
+            )
+            print(result)
         # Preserve raw result XML just in case we need to create a dump.
         # If the decoded result XML cannot be parsed with the XML parser,
         # a dump may need to be taken to aid in problem determination.
-        self.__raw_result_xml = b"".join(result["resultBuffers"])
+        self.__raw_result_xml = result["resultBuffer"]
         # Replace any null bytes in the result XML with spaces.
         result_xml = self.__null_byte_fix(self.__raw_result_xml)
         # 'irrsmo00.c' returns a raw unmodified bytes object containing a copy

--- a/pyracf/common/irrsmo00.py
+++ b/pyracf/common/irrsmo00.py
@@ -80,6 +80,7 @@ class IRRSMO00:
                 irrsmo00_options=irrsmo00_options,
                 running_userid=running_userid,
                 running_userid_len=len(running_userid),
+                handle=result["handle"],
             )
             print(result)
         # Preserve raw result XML just in case we need to create a dump.

--- a/pyracf/common/irrsmo00.py
+++ b/pyracf/common/irrsmo00.py
@@ -61,18 +61,16 @@ class IRRSMO00:
             running_userid = run_as_userid.encode("cp1047")
         result = call_irrsmo00(
             request_xml=request_xml,
-            request_xml_length=len(request_xml),
             result_buffer_size=self.__result_buffer_size,
             irrsmo00_options=irrsmo00_options,
             running_userid=running_userid,
-            running_userid_length=len(running_userid),
         )
         # Preserve raw result XML just in case we need to create a dump.
         # If the decoded result XML cannot be parsed with the XML parser,
         # a dump may need to be taken to aid in problem determination.
-        self.__raw_result_xml = result[0]
+        self.__raw_result_xml = result["resultBuffer"]
         # Replace any null bytes in the result XML with spaces.
-        result_xml = self.__null_byte_fix(result[0])
+        result_xml = self.__null_byte_fix(result["resultBuffer"])
         # 'irrsmo00.c' returns a raw unmodified bytes object containing a copy
         # of the exact contents of the result xml buffer that the IRRSMO00
         # callable service populates.
@@ -88,5 +86,9 @@ class IRRSMO00:
         # service was unable to process the request. in this case, would should
         # only return the return and reasons codes for error handling downstream.
         if result_xml_length == 0:
-            return list(result[1:4])
+            return [
+                result["safReturnCode"],
+                result["racfReturnCode"],
+                result["racfReasonCode"],
+            ]
         return result_xml[:result_xml_length].decode("cp1047")

--- a/pyracf/common/irrsmo00.py
+++ b/pyracf/common/irrsmo00.py
@@ -86,7 +86,7 @@ class IRRSMO00:
         # Preserve raw result XML just in case we need to create a dump.
         # If the decoded result XML cannot be parsed with the XML parser,
         # a dump may need to be taken to aid in problem determination.
-        self.__raw_result_xml = b"".join(result["resultBuffers"])
+        self.__raw_result_xml = result["resultBuffer"]
         # Replace any null bytes in the result XML with spaces.
         result_xml = self.__null_byte_fix(self.__raw_result_xml)
         # 'irrsmo00.c' returns a raw unmodified bytes object containing a copy

--- a/pyracf/common/irrsmo00.py
+++ b/pyracf/common/irrsmo00.py
@@ -61,16 +61,18 @@ class IRRSMO00:
             running_userid = run_as_userid.encode("cp1047")
         result = call_irrsmo00(
             request_xml=request_xml,
+            request_xml_len=len(request_xml),
             result_buffer_size=self.__result_buffer_size,
             irrsmo00_options=irrsmo00_options,
             running_userid=running_userid,
+            running_userid_len=len(running_userid),
         )
         # Preserve raw result XML just in case we need to create a dump.
         # If the decoded result XML cannot be parsed with the XML parser,
         # a dump may need to be taken to aid in problem determination.
-        self.__raw_result_xml = result["resultBuffer"]
+        self.__raw_result_xml = b"".join(result["resultBuffers"])
         # Replace any null bytes in the result XML with spaces.
-        result_xml = self.__null_byte_fix(result["resultBuffer"])
+        result_xml = self.__null_byte_fix(self.__raw_result_xml)
         # 'irrsmo00.c' returns a raw unmodified bytes object containing a copy
         # of the exact contents of the result xml buffer that the IRRSMO00
         # callable service populates.
@@ -86,9 +88,5 @@ class IRRSMO00:
         # service was unable to process the request. in this case, would should
         # only return the return and reasons codes for error handling downstream.
         if result_xml_length == 0:
-            return [
-                result["safReturnCode"],
-                result["racfReturnCode"],
-                result["racfReasonCode"],
-            ]
+            return result["returnCodes"]
         return result_xml[:result_xml_length].decode("cp1047")

--- a/pyracf/common/irrsmo00.py
+++ b/pyracf/common/irrsmo00.py
@@ -67,25 +67,10 @@ class IRRSMO00:
             running_userid=running_userid,
             running_userid_len=len(running_userid),
         )
-        if (
-            (result["returnCodes"][0] == 8)
-            and (result["returnCodes"][1] == 4000)
-            and (result["returnCodes"][2] < 100000000)
-        ):
-            print(result)
-            result = call_irrsmo00(
-                request_xml=request_xml,
-                request_xml_len=len(request_xml),
-                result_buffer_size=result["returnCodes"][2],
-                irrsmo00_options=irrsmo00_options,
-                running_userid=running_userid,
-                running_userid_len=len(running_userid),
-            )
-            print(result)
         # Preserve raw result XML just in case we need to create a dump.
         # If the decoded result XML cannot be parsed with the XML parser,
         # a dump may need to be taken to aid in problem determination.
-        self.__raw_result_xml = result["resultBuffer"]
+        self.__raw_result_xml = b"".join(result["resultBuffers"])
         # Replace any null bytes in the result XML with spaces.
         result_xml = self.__null_byte_fix(self.__raw_result_xml)
         # 'irrsmo00.c' returns a raw unmodified bytes object containing a copy

--- a/tests/common/test_irrsmo00_interface.py
+++ b/tests/common/test_irrsmo00_interface.py
@@ -57,11 +57,8 @@ class TestIRRSMO00Interface(unittest.TestCase):
         ])
         # fmt: on
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": xml_containing_null_bytes,
-            "handlePointer": 0,
-            "safReturnCode": 0,
-            "racfReturnCode": 0,
-            "racfReasonCode": 0,
+            "resultBuffers": [xml_containing_null_bytes],
+            "returnCodes": [0, 0, 0],
         }
         self.assertEqual(
             self.irrsmo00.call_racf(b""),
@@ -74,11 +71,8 @@ class TestIRRSMO00Interface(unittest.TestCase):
     ):
         # Simulate failure due to incomplete 'IRR.IRRSMO00.PRECHECK' setup
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": bytes([0 for i in range(256)]),
-            "handlePointer": 0,
-            "safReturnCode": 8,
-            "racfReturnCode": 200,
-            "racfReasonCode": 16,
+            "resultBuffers": [bytes([0 for i in range(256)])],
+            "returnCodes": [8, 200, 16],
         }
         self.assertEqual(self.irrsmo00.call_racf(b""), [8, 200, 16])
 
@@ -88,11 +82,8 @@ class TestIRRSMO00Interface(unittest.TestCase):
     ):
         # Simulate scenario where result buffer is too small.
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": self.good_xml[:32],
-            "handlePointer": 0,
-            "safReturnCode": 8,
-            "racfReturnCode": 4000,
-            "racfReasonCode": 32,
+            "resultBuffers": [self.good_xml[:32]],
+            "returnCodes": [8, 4000, 32],
         }
         self.assertEqual(
             self.irrsmo00.call_racf(b""), self.good_xml.decode("cp1047")[:32]
@@ -104,11 +95,8 @@ class TestIRRSMO00Interface(unittest.TestCase):
     ):
         # Simulate scenario where result buffer is exactly the right size.
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": self.good_xml[: self.good_xml_null_terminator_index],
-            "handlePointer": 0,
-            "safReturnCode": 0,
-            "racfReturnCode": 0,
-            "racfReasonCode": 0,
+            "resultBuffers": [self.good_xml[: self.good_xml_null_terminator_index]],
+            "returnCodes": [0, 0, 0],
         }
         self.assertEqual(
             self.irrsmo00.call_racf(b""),
@@ -117,11 +105,8 @@ class TestIRRSMO00Interface(unittest.TestCase):
 
     def test_irrsmo00_normal_result(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": self.good_xml,
-            "handlePointer": 0,
-            "safReturnCode": 0,
-            "racfReturnCode": 0,
-            "racfReasonCode": 0,
+            "resultBuffers": [self.good_xml],
+            "returnCodes": [0, 0, 0],
         }
         self.assertEqual(
             self.irrsmo00.call_racf(b""),
@@ -133,67 +118,63 @@ class TestIRRSMO00Interface(unittest.TestCase):
     # ============================================================================
     def test_irrsmo00_minimum_arguments(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": self.good_xml,
-            "handlePointer": 0,
-            "safReturnCode": 0,
-            "racfReturnCode": 0,
-            "racfReasonCode": 0,
+            "resultBuffers": [self.good_xml],
+            "returnCodes": [0, 0, 0],
         }
         self.irrsmo00.call_racf(b"some bytes")
         call_irrsmo00_wrapper_mock.assert_called_with(
             request_xml=b"some bytes",
+            request_xml_len=10,
             result_buffer_size=16384,
             irrsmo00_options=13,
             running_userid=b"",
+            running_userid_len=0,
         )
 
     def test_irrsmo00_with_precheck_set_to_true(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": self.good_xml,
-            "handlePointer": 0,
-            "safReturnCode": 0,
-            "racfReturnCode": 0,
-            "racfReasonCode": 0,
+            "resultBuffers": [self.good_xml],
+            "returnCodes": [0, 0, 0],
         }
         self.irrsmo00.call_racf(b"some bytes", precheck=True)
         call_irrsmo00_wrapper_mock.assert_called_with(
             request_xml=b"some bytes",
+            request_xml_len=10,
             result_buffer_size=16384,
             irrsmo00_options=15,
             running_userid=b"",
+            running_userid_len=0,
         )
 
     def test_irrsmo00_with_run_as_userid_set(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": self.good_xml,
-            "handlePointer": 0,
-            "safReturnCode": 0,
-            "racfReturnCode": 0,
-            "racfReasonCode": 0,
+            "resultBuffers": [self.good_xml],
+            "returnCodes": [0, 0, 0],
         }
         self.irrsmo00.call_racf(b"some bytes", run_as_userid="KRABS")
         call_irrsmo00_wrapper_mock.assert_called_with(
             request_xml=b"some bytes",
+            request_xml_len=10,
             result_buffer_size=16384,
             irrsmo00_options=13,
             running_userid=b"\xd2\xd9\xc1\xc2\xe2",
+            running_userid_len=5,
         )
 
     def test_irrsmo00_with_custom_result_buffer_size(
         self, call_irrsmo00_wrapper_mock: Mock
     ):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": self.good_xml,
-            "handlePointer": 0,
-            "safReturnCode": 0,
-            "racfReturnCode": 0,
-            "racfReasonCode": 0,
+            "resultBuffers": [self.good_xml],
+            "returnCodes": [0, 0, 0],
         }
         irrsmo00 = IRRSMO00(result_buffer_size=32768)
         irrsmo00.call_racf(b"some bytes")
         call_irrsmo00_wrapper_mock.assert_called_with(
             request_xml=b"some bytes",
+            request_xml_len=10,
             result_buffer_size=32768,
             irrsmo00_options=13,
             running_userid=b"",
+            running_userid_len=0,
         )

--- a/tests/common/test_irrsmo00_interface.py
+++ b/tests/common/test_irrsmo00_interface.py
@@ -57,7 +57,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
         ])
         # fmt: on
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [xml_containing_null_bytes],
+            "resultBuffer": xml_containing_null_bytes,
             "returnCodes": [0, 0, 0],
         }
         self.assertEqual(
@@ -71,7 +71,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
     ):
         # Simulate failure due to incomplete 'IRR.IRRSMO00.PRECHECK' setup
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [bytes([0 for i in range(256)])],
+            "resultBuffer": bytes([0 for i in range(256)]),
             "returnCodes": [8, 200, 16],
         }
         self.assertEqual(self.irrsmo00.call_racf(b""), [8, 200, 16])
@@ -82,7 +82,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
     ):
         # Simulate scenario where result buffer is too small.
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [self.good_xml[:32]],
+            "resultBuffer": self.good_xml[:32],
             "returnCodes": [8, 4000, 100000000],
         }
         self.assertEqual(
@@ -95,7 +95,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
     ):
         # Simulate scenario where result buffer is exactly the right size.
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [self.good_xml[: self.good_xml_null_terminator_index]],
+            "resultBuffer": self.good_xml[: self.good_xml_null_terminator_index],
             "returnCodes": [0, 0, 0],
         }
         self.assertEqual(
@@ -105,7 +105,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
 
     def test_irrsmo00_normal_result(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [self.good_xml],
+            "resultBuffer": self.good_xml,
             "returnCodes": [0, 0, 0],
         }
         self.assertEqual(
@@ -118,7 +118,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
     # ============================================================================
     def test_irrsmo00_minimum_arguments(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [self.good_xml],
+            "resultBuffer": self.good_xml,
             "returnCodes": [0, 0, 0],
         }
         self.irrsmo00.call_racf(b"some bytes")
@@ -133,7 +133,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
 
     def test_irrsmo00_with_precheck_set_to_true(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [self.good_xml],
+            "resultBuffer": self.good_xml,
             "returnCodes": [0, 0, 0],
         }
         self.irrsmo00.call_racf(b"some bytes", precheck=True)
@@ -148,7 +148,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
 
     def test_irrsmo00_with_run_as_userid_set(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [self.good_xml],
+            "resultBuffer": self.good_xml,
             "returnCodes": [0, 0, 0],
         }
         self.irrsmo00.call_racf(b"some bytes", run_as_userid="KRABS")
@@ -165,7 +165,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
         self, call_irrsmo00_wrapper_mock: Mock
     ):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [self.good_xml],
+            "resultBuffer": self.good_xml,
             "returnCodes": [0, 0, 0],
         }
         irrsmo00 = IRRSMO00(result_buffer_size=32768)

--- a/tests/common/test_irrsmo00_interface.py
+++ b/tests/common/test_irrsmo00_interface.py
@@ -57,7 +57,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
         ])
         # fmt: on
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [xml_containing_null_bytes],
+            "resultBuffer": xml_containing_null_bytes,
             "returnCodes": [0, 0, 0],
         }
         self.assertEqual(
@@ -71,7 +71,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
     ):
         # Simulate failure due to incomplete 'IRR.IRRSMO00.PRECHECK' setup
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [bytes([0 for i in range(256)])],
+            "resultBuffer": bytes([0 for i in range(256)]),
             "returnCodes": [8, 200, 16],
         }
         self.assertEqual(self.irrsmo00.call_racf(b""), [8, 200, 16])
@@ -82,12 +82,31 @@ class TestIRRSMO00Interface(unittest.TestCase):
     ):
         # Simulate scenario where result buffer is too small.
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [self.good_xml[:32]],
-            "returnCodes": [8, 4000, 32],
+            "resultBuffer": self.good_xml[:32],
+            "returnCodes": [8, 4000, 100000000],
         }
         self.assertEqual(
             self.irrsmo00.call_racf(b""), self.good_xml.decode("cp1047")[:32]
         )
+
+    # def test_irrsmo00_result_buffer_full_redrive(
+    #     self,
+    #     call_irrsmo00_wrapper_mock: Mock,
+    # ):
+    #     # Simulate scenario where result buffer is too small.
+    #     call_irrsmo00_wrapper_mock.side_effect = [
+    #     {
+    #         "resultBuffer": self.good_xml[:32],
+    #         "returnCodes": [8, 4000, 32],
+    #     },
+    #     {
+    #         "resultBuffer": self.good_xml[32:],
+    #         "returnCodes": [0, 0, 0],
+    #     },
+    #     ]
+    #     self.assertEqual(
+    #         self.irrsmo00.call_racf(b""), self.good_xml.decode("cp1047")
+    #     )
 
     def test_irrsmo00_result_buffer_full_success(
         self,
@@ -95,7 +114,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
     ):
         # Simulate scenario where result buffer is exactly the right size.
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [self.good_xml[: self.good_xml_null_terminator_index]],
+            "resultBuffer": self.good_xml[: self.good_xml_null_terminator_index],
             "returnCodes": [0, 0, 0],
         }
         self.assertEqual(
@@ -105,7 +124,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
 
     def test_irrsmo00_normal_result(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [self.good_xml],
+            "resultBuffer": self.good_xml,
             "returnCodes": [0, 0, 0],
         }
         self.assertEqual(
@@ -118,7 +137,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
     # ============================================================================
     def test_irrsmo00_minimum_arguments(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [self.good_xml],
+            "resultBuffer": self.good_xml,
             "returnCodes": [0, 0, 0],
         }
         self.irrsmo00.call_racf(b"some bytes")
@@ -133,7 +152,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
 
     def test_irrsmo00_with_precheck_set_to_true(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [self.good_xml],
+            "resultBuffer": self.good_xml,
             "returnCodes": [0, 0, 0],
         }
         self.irrsmo00.call_racf(b"some bytes", precheck=True)
@@ -148,7 +167,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
 
     def test_irrsmo00_with_run_as_userid_set(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [self.good_xml],
+            "resultBuffer": self.good_xml,
             "returnCodes": [0, 0, 0],
         }
         self.irrsmo00.call_racf(b"some bytes", run_as_userid="KRABS")
@@ -165,7 +184,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
         self, call_irrsmo00_wrapper_mock: Mock
     ):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffers": [self.good_xml],
+            "resultBuffer": self.good_xml,
             "returnCodes": [0, 0, 0],
         }
         irrsmo00 = IRRSMO00(result_buffer_size=32768)

--- a/tests/common/test_irrsmo00_interface.py
+++ b/tests/common/test_irrsmo00_interface.py
@@ -56,7 +56,13 @@ class TestIRRSMO00Interface(unittest.TestCase):
             0, 0, 0, 0, 0, 0,
         ])
         # fmt: on
-        call_irrsmo00_wrapper_mock.return_value = [xml_containing_null_bytes, 0, 0, 0]
+        call_irrsmo00_wrapper_mock.return_value = {
+            "resultBuffer": xml_containing_null_bytes,
+            "handlePointer": 0,
+            "safReturnCode": 0,
+            "racfReturnCode": 0,
+            "racfReasonCode": 0,
+        }
         self.assertEqual(
             self.irrsmo00.call_racf(b""),
             self.good_xml.decode("cp1047")[: self.good_xml_null_terminator_index],
@@ -67,12 +73,13 @@ class TestIRRSMO00Interface(unittest.TestCase):
         call_irrsmo00_wrapper_mock: Mock,
     ):
         # Simulate failure due to incomplete 'IRR.IRRSMO00.PRECHECK' setup
-        call_irrsmo00_wrapper_mock.return_value = [
-            bytes([0 for i in range(256)]),
-            8,
-            200,
-            16,
-        ]
+        call_irrsmo00_wrapper_mock.return_value = {
+            "resultBuffer": bytes([0 for i in range(256)]),
+            "handlePointer": 0,
+            "safReturnCode": 8,
+            "racfReturnCode": 200,
+            "racfReasonCode": 16,
+        }
         self.assertEqual(self.irrsmo00.call_racf(b""), [8, 200, 16])
 
     def test_irrsmo00_result_buffer_full_failure(
@@ -80,7 +87,13 @@ class TestIRRSMO00Interface(unittest.TestCase):
         call_irrsmo00_wrapper_mock: Mock,
     ):
         # Simulate scenario where result buffer is too small.
-        call_irrsmo00_wrapper_mock.return_value = [self.good_xml[:32], 8, 4000, 32]
+        call_irrsmo00_wrapper_mock.return_value = {
+            "resultBuffer": self.good_xml[:32],
+            "handlePointer": 0,
+            "safReturnCode": 8,
+            "racfReturnCode": 4000,
+            "racfReasonCode": 32,
+        }
         self.assertEqual(
             self.irrsmo00.call_racf(b""), self.good_xml.decode("cp1047")[:32]
         )
@@ -90,19 +103,26 @@ class TestIRRSMO00Interface(unittest.TestCase):
         call_irrsmo00_wrapper_mock: Mock,
     ):
         # Simulate scenario where result buffer is exactly the right size.
-        call_irrsmo00_wrapper_mock.return_value = [
-            self.good_xml[: self.good_xml_null_terminator_index],
-            0,
-            0,
-            0,
-        ]
+        call_irrsmo00_wrapper_mock.return_value = {
+            "resultBuffer": self.good_xml[: self.good_xml_null_terminator_index],
+            "handlePointer": 0,
+            "safReturnCode": 0,
+            "racfReturnCode": 0,
+            "racfReasonCode": 0,
+        }
         self.assertEqual(
             self.irrsmo00.call_racf(b""),
             self.good_xml.decode("cp1047")[: self.good_xml_null_terminator_index],
         )
 
     def test_irrsmo00_normal_result(self, call_irrsmo00_wrapper_mock: Mock):
-        call_irrsmo00_wrapper_mock.return_value = [self.good_xml, 0, 0, 0]
+        call_irrsmo00_wrapper_mock.return_value = {
+            "resultBuffer": self.good_xml,
+            "handlePointer": 0,
+            "safReturnCode": 0,
+            "racfReturnCode": 0,
+            "racfReasonCode": 0,
+        }
         self.assertEqual(
             self.irrsmo00.call_racf(b""),
             self.good_xml.decode("cp1047")[: self.good_xml_null_terminator_index],
@@ -112,52 +132,68 @@ class TestIRRSMO00Interface(unittest.TestCase):
     # Test IRRSMO00 Argument Construction
     # ============================================================================
     def test_irrsmo00_minimum_arguments(self, call_irrsmo00_wrapper_mock: Mock):
-        call_irrsmo00_wrapper_mock.return_value = [self.good_xml, 0, 0, 0]
+        call_irrsmo00_wrapper_mock.return_value = {
+            "resultBuffer": self.good_xml,
+            "handlePointer": 0,
+            "safReturnCode": 0,
+            "racfReturnCode": 0,
+            "racfReasonCode": 0,
+        }
         self.irrsmo00.call_racf(b"some bytes")
         call_irrsmo00_wrapper_mock.assert_called_with(
             request_xml=b"some bytes",
-            request_xml_length=10,
             result_buffer_size=16384,
             irrsmo00_options=13,
             running_userid=b"",
-            running_userid_length=0,
         )
 
     def test_irrsmo00_with_precheck_set_to_true(self, call_irrsmo00_wrapper_mock: Mock):
-        call_irrsmo00_wrapper_mock.return_value = [self.good_xml, 0, 0, 0]
+        call_irrsmo00_wrapper_mock.return_value = {
+            "resultBuffer": self.good_xml,
+            "handlePointer": 0,
+            "safReturnCode": 0,
+            "racfReturnCode": 0,
+            "racfReasonCode": 0,
+        }
         self.irrsmo00.call_racf(b"some bytes", precheck=True)
         call_irrsmo00_wrapper_mock.assert_called_with(
             request_xml=b"some bytes",
-            request_xml_length=10,
             result_buffer_size=16384,
             irrsmo00_options=15,
             running_userid=b"",
-            running_userid_length=0,
         )
 
     def test_irrsmo00_with_run_as_userid_set(self, call_irrsmo00_wrapper_mock: Mock):
-        call_irrsmo00_wrapper_mock.return_value = [self.good_xml, 0, 0, 0]
+        call_irrsmo00_wrapper_mock.return_value = {
+            "resultBuffer": self.good_xml,
+            "handlePointer": 0,
+            "safReturnCode": 0,
+            "racfReturnCode": 0,
+            "racfReasonCode": 0,
+        }
         self.irrsmo00.call_racf(b"some bytes", run_as_userid="KRABS")
         call_irrsmo00_wrapper_mock.assert_called_with(
             request_xml=b"some bytes",
-            request_xml_length=10,
             result_buffer_size=16384,
             irrsmo00_options=13,
             running_userid=b"\xd2\xd9\xc1\xc2\xe2",
-            running_userid_length=5,
         )
 
     def test_irrsmo00_with_custom_result_buffer_size(
         self, call_irrsmo00_wrapper_mock: Mock
     ):
-        call_irrsmo00_wrapper_mock.return_value = [self.good_xml, 0, 0, 0]
+        call_irrsmo00_wrapper_mock.return_value = {
+            "resultBuffer": self.good_xml,
+            "handlePointer": 0,
+            "safReturnCode": 0,
+            "racfReturnCode": 0,
+            "racfReasonCode": 0,
+        }
         irrsmo00 = IRRSMO00(result_buffer_size=32768)
         irrsmo00.call_racf(b"some bytes")
         call_irrsmo00_wrapper_mock.assert_called_with(
             request_xml=b"some bytes",
-            request_xml_length=10,
             result_buffer_size=32768,
             irrsmo00_options=13,
             running_userid=b"",
-            running_userid_length=0,
         )

--- a/tests/common/test_irrsmo00_interface.py
+++ b/tests/common/test_irrsmo00_interface.py
@@ -57,7 +57,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
         ])
         # fmt: on
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": xml_containing_null_bytes,
+            "resultBuffers": [xml_containing_null_bytes],
             "returnCodes": [0, 0, 0],
         }
         self.assertEqual(
@@ -71,7 +71,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
     ):
         # Simulate failure due to incomplete 'IRR.IRRSMO00.PRECHECK' setup
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": bytes([0 for i in range(256)]),
+            "resultBuffers": [bytes([0 for i in range(256)])],
             "returnCodes": [8, 200, 16],
         }
         self.assertEqual(self.irrsmo00.call_racf(b""), [8, 200, 16])
@@ -82,31 +82,12 @@ class TestIRRSMO00Interface(unittest.TestCase):
     ):
         # Simulate scenario where result buffer is too small.
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": self.good_xml[:32],
-            "returnCodes": [8, 4000, 100000000],
+            "resultBuffers": [self.good_xml[:32]],
+            "returnCodes": [8, 4000, 32],
         }
         self.assertEqual(
             self.irrsmo00.call_racf(b""), self.good_xml.decode("cp1047")[:32]
         )
-
-    # def test_irrsmo00_result_buffer_full_redrive(
-    #     self,
-    #     call_irrsmo00_wrapper_mock: Mock,
-    # ):
-    #     # Simulate scenario where result buffer is too small.
-    #     call_irrsmo00_wrapper_mock.side_effect = [
-    #     {
-    #         "resultBuffer": self.good_xml[:32],
-    #         "returnCodes": [8, 4000, 32],
-    #     },
-    #     {
-    #         "resultBuffer": self.good_xml[32:],
-    #         "returnCodes": [0, 0, 0],
-    #     },
-    #     ]
-    #     self.assertEqual(
-    #         self.irrsmo00.call_racf(b""), self.good_xml.decode("cp1047")
-    #     )
 
     def test_irrsmo00_result_buffer_full_success(
         self,
@@ -114,7 +95,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
     ):
         # Simulate scenario where result buffer is exactly the right size.
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": self.good_xml[: self.good_xml_null_terminator_index],
+            "resultBuffers": [self.good_xml[: self.good_xml_null_terminator_index]],
             "returnCodes": [0, 0, 0],
         }
         self.assertEqual(
@@ -124,7 +105,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
 
     def test_irrsmo00_normal_result(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": self.good_xml,
+            "resultBuffers": [self.good_xml],
             "returnCodes": [0, 0, 0],
         }
         self.assertEqual(
@@ -137,7 +118,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
     # ============================================================================
     def test_irrsmo00_minimum_arguments(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": self.good_xml,
+            "resultBuffers": [self.good_xml],
             "returnCodes": [0, 0, 0],
         }
         self.irrsmo00.call_racf(b"some bytes")
@@ -152,7 +133,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
 
     def test_irrsmo00_with_precheck_set_to_true(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": self.good_xml,
+            "resultBuffers": [self.good_xml],
             "returnCodes": [0, 0, 0],
         }
         self.irrsmo00.call_racf(b"some bytes", precheck=True)
@@ -167,7 +148,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
 
     def test_irrsmo00_with_run_as_userid_set(self, call_irrsmo00_wrapper_mock: Mock):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": self.good_xml,
+            "resultBuffers": [self.good_xml],
             "returnCodes": [0, 0, 0],
         }
         self.irrsmo00.call_racf(b"some bytes", run_as_userid="KRABS")
@@ -184,7 +165,7 @@ class TestIRRSMO00Interface(unittest.TestCase):
         self, call_irrsmo00_wrapper_mock: Mock
     ):
         call_irrsmo00_wrapper_mock.return_value = {
-            "resultBuffer": self.good_xml,
+            "resultBuffers": [self.good_xml],
             "returnCodes": [0, 0, 0],
         }
         irrsmo00 = IRRSMO00(result_buffer_size=32768)


### PR DESCRIPTION
### :bulb: Issue Reference

**Issue:**  #71 

### :computer: What does this address?

Now that users can specify buffer sizes as a part of the class constructor, we need to dynamically respond to the buffer size being too small to hold the response xml.

### :pager: Implementation Details

At the C code level, if the failing request is detected, a new buffer is allocated large enough for the remaining response and the request is re-driven. If the buffer would need to be larger than the maximum tolerable size for our constructor, we fail and surface the error as a DownstreamFatalError with IRRSMO00's return and reason codes.

### :clipboard: Is there a test case?

Since this re-drive is done at the c level, there are no applicable unit tests available. A function test could be added, but we would need confirmation that the environment is appropriate for the test (a command and buffer size must be chosen that we KNOW would fail prior to this feature which may differ dependent on the environment and authority bestowed to pyRACF).

On our test system, I ran two tests. One with setropts_admin.list_racf_options with a buffer specified at 10000 bytes (the minimum) which failed before the added code and now succeeds, and one with resource_admin.extract("*","FACILITY) with the default 16KB buffer which failed and now succeeds.